### PR TITLE
sprite: ARM64

### DIFF
--- a/.github/workflows/sprite.yml
+++ b/.github/workflows/sprite.yml
@@ -53,13 +53,13 @@ jobs:
         cd b
         cmake \
           -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-          -DCMAKE_OSX_ARCHITECTURES=x86_64 \
-          -DCMAKE_OSX_DEPLOYMENT_TARGET=10.9 \
+          -DCMAKE_OSX_ARCHITECTURES=arm64 \
+          -DCMAKE_OSX_DEPLOYMENT_TARGET=11.0 \
           -DCMAKE_OSX_SYSROOT=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk \
           -DLAF_BACKEND=skia \
           -DSKIA_DIR=../c \
-          -DSKIA_LIBRARY_DIR=../c/out/Release-x64 \
-          -DSKIA_LIBRARY=../c/out/Release-x64/libskia.a \
+          -DSKIA_LIBRARY_DIR=../c/out/Release-arm64 \
+          -DSKIA_LIBRARY=../c/out/Release-arm64/libskia.a \
           -G Ninja ../a
         ninja aseprite
         7z a b.7z bin


### PR DESCRIPTION
Aseprite官网的体验版貌似只支持ARM64。

等到GitHub支持M1运行器（预计[今年四季度](https://github.com/github/roadmap/issues/528)），就切换到ARM64目标，然后尝试把体验版的安装包做成开发版。

```sh
TRIAL_VERSION=$(curl "https://aseprite.org/trial/" | grep -om 1 'v\d\+\.\d\+\.\d\+')
curl -LO "https://aseprite.org/downloads/trial/Aseprite-v1.2.40-trial-macOS.dmg"
yes | hdiutil attach Aseprite-v1.2.40-trial-macOS.dmg -shadow | cat
cp bin/aseprite /Volumes/Aseprite*/Aseprite.app/Contents/MacOS/aseprite
hdiutil detach /dev/disk9 \
  || hdiutil detach /dev/disk8 \
  || hdiutil detach /dev/disk7 \
  || hdiutil detach /dev/disk6 \
  || hdiutil detach /dev/disk5 \
  || hdiutil detach /dev/disk4 \
  || hdiutil detach /dev/disk3 \
  || hdiutil detach /dev/disk2 \
  || hdiutil detach /dev/disk1 # 不知道怎么获取这个数字，就一个个试过去吧
hdiutil convert -format UDZO -o b.dmg Aseprite-v1.2.40-trial-macOS.dmg -shadow
```

- [ ] 测试复选框